### PR TITLE
Ensure UDP hole-punching is always used.

### DIFF
--- a/client/connectivity/balancer.go
+++ b/client/connectivity/balancer.go
@@ -1,0 +1,50 @@
+package connectivity
+
+import (
+	pb "github.com/sgielen/rufs/proto"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+)
+
+const BalancerName string = "rufs"
+
+func init() {
+	// Use the base implementation of the balancer. It attempts to create a subconn (channel) for each
+	// address, allowing us to pick the address to use.
+	balancer.Register(base.NewBalancerBuilder(BalancerName, &rufsPickerBuilder{}, base.Config{HealthCheck: true}))
+}
+
+type rufsPickerBuilder struct{}
+
+func (*rufsPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
+	// Normally, a picker considers all subconns to point to different nodes.
+	// In this case, it makes sense to balance requests over them to spread load.
+	// In our case, however, we know that they are various connections to the
+	// same node. Hence, we try to pick the most efficient connection, preferring
+	// TCP over UDP, but we only pre-pick a single subconn. If the set of ready
+	// subconns changes, this method will be invoked to pick the new best one.
+
+	// Attempt to use the first ready TCP subconn.
+	for subconn, sinfo := range info.ReadySCs {
+		endpointType, _ := splitGrpcAddress(sinfo.Address.Addr)
+		if endpointType == pb.Endpoint_TCP {
+			return &rufsPicker{subConn: subconn}
+		}
+	}
+
+	// Otherwise, just use any first one.
+	for subconn, _ := range info.ReadySCs {
+		return &rufsPicker{subConn: subconn}
+	}
+
+	// No SCs ready? Return an error picker.
+	return base.NewErrPicker(balancer.ErrNoSubConnAvailable)
+}
+
+type rufsPicker struct {
+	subConn balancer.SubConn
+}
+
+func (p *rufsPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
+	return balancer.PickResult{SubConn: p.subConn}, nil
+}

--- a/client/connectivity/balancer.go
+++ b/client/connectivity/balancer.go
@@ -6,12 +6,12 @@ import (
 	"google.golang.org/grpc/balancer/base"
 )
 
-const BalancerName string = "rufs"
+const BalancerName string = "rufs-peer"
 
 func init() {
 	// Use the base implementation of the balancer. It attempts to create a subconn (channel) for each
 	// address, allowing us to pick the address to use.
-	balancer.Register(base.NewBalancerBuilder(BalancerName, &rufsPickerBuilder{}, base.Config{HealthCheck: true}))
+	balancer.Register(base.NewBalancerBuilder(BalancerName, &rufsPickerBuilder{}, base.Config{}))
 }
 
 type rufsPickerBuilder struct{}

--- a/client/connectivity/connectivity.go
+++ b/client/connectivity/connectivity.go
@@ -236,7 +236,8 @@ func (c *circle) newPeer(ctx context.Context, p *pb.Peer) *Peer {
 		// and this method of communication is preferred, the client should still
 		// also connect using UDP; if not, the other client may not be able to
 		// connect to the first client at all.
-		grpc.WithBalancerName(BalancerName),
+		grpc.WithDisableServiceConfig(),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [ { "`+BalancerName+`": {} } ]}`),
 	)
 	if err != nil {
 		log.Fatalf("Failed to dial peer %q: %v", r.Scheme(), err)

--- a/client/connectivity/connectivity.go
+++ b/client/connectivity/connectivity.go
@@ -230,6 +230,13 @@ func (c *circle) newPeer(ctx context.Context, p *pb.Peer) *Peer {
 		grpc.WithContextDialer(c.dialPeer),
 		grpc.WithTransportCredentials(credentials.NewTLS(c.keyPair.TLSConfigForServerClient(p.GetName()))),
 		keepaliveOption,
+		// gRPC should keep a channel open to all endpoints, since UDP hole-punching
+		// between two clients may only work if they are trying to connect to each
+		// other via UDP. Hence, even if one client can connect to the other via TCP,
+		// and this method of communication is preferred, the client should still
+		// also connect using UDP; if not, the other client may not be able to
+		// connect to the first client at all.
+		grpc.WithBalancerName(BalancerName),
 	)
 	if err != nil {
 		log.Fatalf("Failed to dial peer %q: %v", r.Scheme(), err)
@@ -242,17 +249,28 @@ func (c *circle) newPeer(ctx context.Context, p *pb.Peer) *Peer {
 }
 
 func (c *circle) dialPeer(ctx context.Context, addr string) (net.Conn, error) {
-	sp := strings.SplitN(addr, ":", 2)
-	addr = sp[1]
-	switch pb.Endpoint_Type(pb.Endpoint_Type_value[sp[0]]) {
+	endpointType, addr := splitGrpcAddress(addr)
+	switch endpointType {
 	case pb.Endpoint_SCTP_OVER_UDP:
 		return c.udpSocket.DialContext(ctx, addr)
 	case pb.Endpoint_TCP:
 		var d net.Dialer
 		return d.DialContext(ctx, "tcp", addr)
 	default:
-		return nil, fmt.Errorf("internal error: unknown endpoint type: %v", sp[0])
+		return nil, fmt.Errorf("internal error: unknown endpoint type in address: %s", addr)
 	}
+}
+
+func joinGrpcAddress(t pb.Endpoint_Type, addr string) string {
+	return t.String() + ":" + addr
+}
+
+func splitGrpcAddress(addr string) (pb.Endpoint_Type, string) {
+	sp := strings.SplitN(addr, ":", 2)
+	if v, ok := pb.Endpoint_Type_value[sp[0]]; ok {
+		return pb.Endpoint_Type(v), sp[1]
+	}
+	return pb.Endpoint_UNKNOWN_TYPE, sp[1]
 }
 
 func peerToResolverState(p *pb.Peer) resolver.State {
@@ -262,7 +280,7 @@ func peerToResolverState(p *pb.Peer) resolver.State {
 			continue
 		}
 		s.Addresses = append(s.Addresses, resolver.Address{
-			Addr:       e.Type.String() + ":" + e.GetAddress(),
+			Addr:       joinGrpcAddress(e.Type, e.GetAddress()),
 			ServerName: p.GetName(),
 		})
 	}


### PR DESCRIPTION
gRPC should keep a channel open to all endpoints, since UDP hole-punching
between two clients may only work if they are trying to connect to each other
via UDP. Hence, even if one client can connect to the other via TCP, and this
method of communication is preferred, the client should still also connect
using UDP; if not, the other client may not be able to connect to the first
client at all.

We get gRPC to work like this by using a balancer that connects to all
addresses, then using a picker that takes the best open connection and sends
all RPCs over it.